### PR TITLE
fix: use percent over vw for width

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -213,7 +213,7 @@ import { Icon } from 'astro-icon';
     grid-auto-rows: 1fr;
     padding: 0;
     margin: 0;
-    width: 100vw;
+    width: 100%;
     box-sizing: border-box;
   }
 


### PR DESCRIPTION

## Description
This removes horizontal scrolling due to overflowing. This happens because vw does not consider the width of the scrollbar.

## This is a **UI Change**
- [x] This has been previewed and looks as intended
