### PR TITLE
feat: redirect to new docs

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -15,7 +15,7 @@ import { Icon } from 'astro-icon';
   </a>
 
   <a href="/blog" class="nav-link"><span>Blog</span></a>
-  <a href="https://eludris.github.io/docs" class="nav-link"><span>Docs</span></a>
+  <a href="https://eludevs.pages.dev" class="nav-link"><span>Docs</span></a>
   <a href="https://github.com/eludris" class="nav-link"><span>GitHub</span></a>
   <div id="button-wrapper">
     <Icon id="moon" class="notransition" width="24px" name="mdi:white-balance-sunny" />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -13,7 +13,7 @@ import { Icon } from 'astro-icon';
       </p>
       <div id="learn-more-wrapper">
         <a class="learn-more-button" href="https://elu.pages.dev"><button> Try it out</button></a>
-        <a class="learn-more-button" href="https://eludris.github.io/docs" target="_blank"
+        <a class="learn-more-button" href="https://eludevs.pages.dev" target="_blank"
           ><button>
             Learn more <Icon name="eva:external-link-fill" />
           </button>


### PR DESCRIPTION
## Description
Since docsv2 has been merged (eludris/eludris#37 eludris/eludris#66), the Learn More button needs to redirect to that documentation now.

<!-- Link any issues if applicable.
Use keywords from https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

## This is a **Content Change**

<!--
## This is a **UI Change**
- [ ] This has been previewed and looks as intended
-->
