### PR TITLE
fix: remove scroll when page fully in view

### DIFF
--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -153,6 +153,7 @@ const stars = fetch('https://api.github.com/repos/Eludris/elusite')
         margin: 0;
       }
 
+      // Enoki made these up by adding the size of nav and footer.
       #content {
         min-height: calc(100vh - 2.95rem - 86px);
       }

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -154,7 +154,7 @@ const stars = fetch('https://api.github.com/repos/Eludris/elusite')
       }
 
       #content {
-        min-height: calc(100vh - 6em);
+        min-height: calc(100vh - 2.95rem - 86px);
       }
 
       footer {


### PR DESCRIPTION
## Description

Fix the issue where if the page (such as blog) is fully in view, you can still scroll a few pixels.

<!-- Explain what this Pull Request changes -->

<!-- Link any issues if applicable.
Use keywords from https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

<!--
## This is a **Content Change**
-->

## This is a **UI Change**

- [x] This has been previewed and looks as intended
